### PR TITLE
feat(repo): add migration repo command

### DIFF
--- a/cmd/bitbucketServer2Gitea/main.go
+++ b/cmd/bitbucketServer2Gitea/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -29,5 +30,7 @@ func withContextFunc(ctx context.Context, f func()) context.Context {
 
 func main() {
 	ctx := withContextFunc(context.Background(), func() {})
-	cmd.Execute(ctx)
+	if err := cmd.Execute(ctx); err != nil {
+		slog.Error("migration error", "msg", err)
+	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path"
 	"strings"
@@ -14,9 +14,10 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Short:        "A command line tool build with Golang to migrate a Bitbucket to Gitea.",
-	SilenceUsage: true,
-	Args:         cobra.MaximumNArgs(1),
+	Short:         "A command line tool build with Golang to migrate a Bitbucket to Gitea.",
+	SilenceUsage:  true,
+	Args:          cobra.MaximumNArgs(1),
+	SilenceErrors: true,
 }
 
 // Used for flags.
@@ -31,6 +32,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/bitbucketServer2Gitea/.config.yaml)")
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(repoCmd)
 
 	// hide completion command
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
@@ -78,13 +80,15 @@ func initConfig() {
 			}
 		} else {
 			// Config file was found but another error was produced
-			fmt.Fprintln(os.Stderr, err)
+			slog.Error("read config error", "msg", err)
 		}
 	}
 }
 
-func Execute(ctx context.Context) {
+func Execute(ctx context.Context) error {
 	if _, err := rootCmd.ExecuteContextC(ctx); err != nil {
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"code.gitea.io/sdk/gitea"
+	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
+	"github.com/spf13/cobra"
+)
+
+var (
+	projectKey  string
+	repoSlug    string
+	targetOwner string
+	targetRepo  string
+)
+
+func init() {
+	repoCmd.PersistentFlags().StringVar(&projectKey, "project-key", "", "the parent project key")
+	repoCmd.PersistentFlags().StringVar(&repoSlug, "repo-slug", "", "the repository slug")
+	repoCmd.PersistentFlags().StringVar(&targetOwner, "target-owner", "", "gitea target owner")
+	repoCmd.PersistentFlags().StringVar(&targetRepo, "target-repo", "", "gitea target repo")
+}
+
+var repoCmd = &cobra.Command{
+	Use:   "repo",
+	Short: "migration single repository",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		m, err := NewMigration(ctx)
+		if err != nil {
+			return err
+		}
+
+		if projectKey == "" || repoSlug == "" {
+			return errors.New("project-key or repo-slug is empty")
+		}
+
+		// check bitbucket project exist
+		response, err := m.bitbucketClient.DefaultApi.GetProject(projectKey)
+		if err != nil {
+			return err
+		}
+
+		org, err := bitbucketv1.GetRepositoryResponse(response)
+		if err != nil {
+			return err
+		}
+
+		response, err = m.bitbucketClient.DefaultApi.GetRepository(projectKey, repoSlug)
+		if err != nil {
+			return err
+		}
+
+		repo, err := bitbucketv1.GetRepositoryResponse(response)
+		if err != nil {
+			return err
+		}
+
+		// check gitea owner exist
+		if targetOwner == "" {
+			targetOwner = org.Name
+		}
+		newOrg, reponse, err := m.giteaClient.GetOrg(targetOwner)
+		if reponse.StatusCode == http.StatusNotFound {
+			visible := gitea.VisibleTypePublic
+			if !org.Public {
+				visible = gitea.VisibleTypePrivate
+			}
+			newOrg, reponse, err = m.giteaClient.CreateOrg(gitea.CreateOrgOption{
+				Name:        targetOwner,
+				Description: org.Description,
+				Visibility:  visible,
+			})
+			if err != nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+
+		if targetRepo == "" {
+			targetRepo = repo.Name
+		}
+
+		newRepo, reponse, err := m.giteaClient.MigrateRepo(gitea.MigrateRepoOption{
+			RepoName:     targetRepo,
+			RepoOwner:    targetOwner,
+			CloneAddr:    repo.Links.Clone[1].Href,
+			Private:      !repo.Public,
+			Description:  repo.Description,
+			AuthUsername: m.bitbucketUsername,
+			AuthPassword: m.bitbucketToken,
+		})
+		if err != nil {
+			return err
+		}
+
+		slog.Info("migrate repo success", "name", newRepo.Name, "owner", newOrg.UserName)
+
+		return nil
+	},
+}

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -72,7 +72,7 @@ var repoCmd = &cobra.Command{
 			if !org.Public {
 				visible = gitea.VisibleTypePrivate
 			}
-			newOrg, reponse, err = m.giteaClient.CreateOrg(gitea.CreateOrgOption{
+			newOrg, _, err = m.giteaClient.CreateOrg(gitea.CreateOrgOption{
 				Name:        targetOwner,
 				Description: org.Description,
 				Visibility:  visible,
@@ -88,7 +88,7 @@ var repoCmd = &cobra.Command{
 			targetRepo = repo.Name
 		}
 
-		newRepo, reponse, err := m.giteaClient.MigrateRepo(gitea.MigrateRepoOption{
+		newRepo, _, err := m.giteaClient.MigrateRepo(gitea.MigrateRepoOption{
 			RepoName:     targetRepo,
 			RepoOwner:    targetOwner,
 			CloneAddr:    repo.Links.Clone[1].Href,


### PR DESCRIPTION
- Add error handling for the `cmd.Execute` function
- Change the return type of the `Execute` function from `void` to `error`
- Add a new file `repo.go` with 108 lines of code